### PR TITLE
feature | CI/CD status badge on PR cards

### DIFF
--- a/docs/superpowers/plans/2026-05-13-cicd-status-badge.md
+++ b/docs/superpowers/plans/2026-05-13-cicd-status-badge.md
@@ -1,0 +1,396 @@
+# CI/CD Status Badge on PR Cards — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a CI/CD status badge (✅ pass / ❌ fail / 🔄 running) to PR cards in the GitPing popup by fetching GitHub check-runs during the background polling cycle.
+
+**Architecture:** A second pass runs `Promise.allSettled` over PR results for 4 tabs (`personal`, `mine`, `team`, `mentions`) after the existing `enrichIssue()` enrichment, fetching check-runs per PR and attaching `ciStatus` to each `pr.card`. The badge is rendered in `cardTitle()` in `uiUtils.js` after the existing status badge.
+
+**Tech Stack:** Vanilla JavaScript (ES6 modules), Chrome Extension Manifest V3, GitHub REST Checks API (`/repos/{owner}/{repo}/commits/{sha}/check-runs`), no build step.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/shared/githubGraphql.js` | Add `headRefOid` to `getPrSchema()` — exposes the PR head commit SHA from GraphQL |
+| `src/shared/githubApi.js` | Add `card.head_sha` in `enrichIssue()`; add `fetchCheckRuns()`; add second CI pass in `fetchAndFilterPullRequests()` |
+| `src/shared/uiUtils.js` | Render CI badge in `cardTitle()` after the existing status badge |
+| `src/shared/design-system.css` | Add `.ci-badge` base styles and modifier variants |
+
+---
+
+## Task 1: Create Feature Branch
+
+- [ ] **Step 1: Create and switch to the feature branch**
+
+```bash
+git checkout -b feature/cicd-status-badge
+```
+
+Expected: `Switched to a new branch 'feature/cicd-status-badge'`
+
+---
+
+## Task 2: Add `headRefOid` to GraphQL PR Schema
+
+`headRefOid` is the GitHub GraphQL field for the PR's head commit SHA. It lives on the `PullRequest` object — one field alongside the existing `commits(last: 1)` block.
+
+**Files:**
+- Modify: `src/shared/githubGraphql.js:64`
+
+- [ ] **Step 1: Add `headRefOid` to `getPrSchema()`**
+
+In `src/shared/githubGraphql.js`, locate the `commits(last: 1) {` block (around line 64) and add `headRefOid` immediately before it:
+
+```js
+// BEFORE:
+            commits(last: 1) {
+
+// AFTER:
+            headRefOid
+            commits(last: 1) {
+```
+
+The full surrounding context for precision:
+
+```js
+            labels(first: 20) {
+                nodes {
+                    name
+                    color
+                    description
+                }
+            }
+
+            headRefOid
+            commits(last: 1) {
+                nodes {
+                    commit {
+```
+
+- [ ] **Step 2: Syntax-check the file**
+
+```bash
+node --check src/shared/githubGraphql.js
+```
+
+Expected: no output (clean pass).
+
+---
+
+## Task 3: Pass `head_sha` Through `enrichIssue()`
+
+`enrichIssue()` builds the `card` object used by the popup. We need `head_sha` on the card so the second CI pass can read it without touching the raw GraphQL response again.
+
+**Files:**
+- Modify: `src/shared/githubApi.js:474` (inside the `result.card = {` block)
+
+- [ ] **Step 1: Add `head_sha` to the `card` object in `enrichIssue()`**
+
+Locate the `result.card = {` block in `enrichIssue()` (around line 474). Add `head_sha` after the `labels` line:
+
+```js
+// BEFORE:
+        labels: labels,
+        meta: meta
+    }
+
+// AFTER:
+        labels: labels,
+        head_sha: issue.headRefOid || null,
+        meta: meta
+    }
+```
+
+- [ ] **Step 2: Syntax-check the file**
+
+```bash
+node --check src/shared/githubApi.js
+```
+
+Expected: no output (clean pass).
+
+---
+
+## Task 4: Implement `fetchCheckRuns()`
+
+This function calls `GET /repos/{owner}/{repo}/commits/{sha}/check-runs` and aggregates all runs into a single `ciStatus`. It uses the existing `fetchFromGitHub` helper.
+
+**Note on the API response shape:** `fetchFromGitHub` returns the raw JSON object. For this endpoint, GitHub returns `{ total_count, check_runs: [...] }` — not a plain array. Access `.check_runs` on the result. Adding `?per_page=100` keeps us under the pagination threshold (no PR has 100+ checks in practice).
+
+**Files:**
+- Modify: `src/shared/githubApi.js` — add new function before `fetchWatchedRepositories`
+
+- [ ] **Step 1: Add `fetchCheckRuns()` to `githubApi.js`**
+
+Locate the comment block before `fetchWatchedRepositories` (around line 499):
+
+```js
+//
+//
+//  WATCHED FUNCTIONS
+//
+//
+```
+
+Insert the new function immediately before that block:
+
+```js
+/**
+ * Fetch CI check-runs for a PR's head commit and return an aggregated status.
+ * @param {string} owner - Repository owner (org or user login).
+ * @param {string} repo - Repository name.
+ * @param {string} sha - The PR head commit SHA.
+ * @param {string} token - GitHub personal access token.
+ * @returns {Promise<'success'|'failure'|'running'|null>}
+ */
+async function fetchCheckRuns(owner, repo, sha, token) {
+    try {
+        const data = await fetchFromGitHub(
+            `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100`,
+            token
+        );
+        const runs = data.check_runs || [];
+        if (runs.length === 0) return null;
+        if (runs.some(r => r.conclusion === 'failure' || r.conclusion === 'timed_out')) return 'failure';
+        if (runs.some(r => r.status === 'in_progress' || r.status === 'queued')) return 'running';
+        if (runs.every(r => r.conclusion === 'success')) return 'success';
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+//
+//
+//  WATCHED FUNCTIONS
+//
+//
+```
+
+- [ ] **Step 2: Syntax-check the file**
+
+```bash
+node --check src/shared/githubApi.js
+```
+
+Expected: no output (clean pass).
+
+---
+
+## Task 5: Add CI Second Pass in `fetchAndFilterPullRequests()`
+
+After the existing enrichment loop, run `Promise.allSettled` over the 4 scoped tabs and attach `ciStatus` to each card. `allSettled` ensures one failed check-runs call never blocks others.
+
+**Files:**
+- Modify: `src/shared/githubApi.js` — inside `fetchAndFilterPullRequests()`, after the enrichment loop
+
+- [ ] **Step 1: Add the second CI pass after the enrichment loop**
+
+Locate the existing enrichment block (around line 577):
+
+```js
+    // enrich all the results
+    Object.keys(results).forEach((key) => {
+        results[key].sort((a, b) => {
+            const aTime = new Date(a.updated_at || a.updatedAt || 0).getTime();
+            const bTime = new Date(b.updated_at || b.updatedAt || 0).getTime();
+            return bTime - aTime;
+        });
+        results[key] = results[key].map(issue => enrichIssue(issue, key));
+    });
+
+    // ensure we set the first update time -- used for display purposes
+    setFirstUpdateTime();
+
+    return results;
+```
+
+Replace with:
+
+```js
+    // enrich all the results
+    Object.keys(results).forEach((key) => {
+        results[key].sort((a, b) => {
+            const aTime = new Date(a.updated_at || a.updatedAt || 0).getTime();
+            const bTime = new Date(b.updated_at || b.updatedAt || 0).getTime();
+            return bTime - aTime;
+        });
+        results[key] = results[key].map(issue => enrichIssue(issue, key));
+    });
+
+    // fetch CI check-runs for PR tabs only
+    const CI_TABS = ['personal', 'mine', 'team', 'mentions'];
+    await Promise.allSettled(
+        CI_TABS.flatMap(key =>
+            (results[key] || [])
+                .filter(pr => pr.card?.head_sha)
+                .map(async pr => {
+                    const [owner, repo] = pr.card.repo_name.split('/');
+                    pr.card.ciStatus = await fetchCheckRuns(owner, repo, pr.card.head_sha, token);
+                })
+        )
+    );
+
+    // ensure we set the first update time -- used for display purposes
+    setFirstUpdateTime();
+
+    return results;
+```
+
+- [ ] **Step 2: Syntax-check the file**
+
+```bash
+node --check src/shared/githubApi.js
+```
+
+Expected: no output (clean pass).
+
+---
+
+## Task 6: Render CI Badge in `cardTitle()`
+
+The badge goes after the existing `pr-status-badge` span in `cardTitle()`. No badge is rendered when `ciStatus` is absent or `null`.
+
+**Files:**
+- Modify: `src/shared/uiUtils.js:248` — after `title.appendChild(statusBadge)`
+
+- [ ] **Step 1: Add CI badge after the status badge in `cardTitle()`**
+
+Locate the end of `cardTitle()` (around line 248):
+
+```js
+    title.appendChild(statusBadge);
+    return title;
+}
+```
+
+Replace with:
+
+```js
+    title.appendChild(statusBadge);
+
+    if (pr.ciStatus) {
+        const ciEmoji = { success: '✅', failure: '❌', running: '🔄' };
+        const ciBadge = document.createElement('span');
+        ciBadge.className = `ci-badge ci-badge--${pr.ciStatus}`;
+        ciBadge.textContent = ciEmoji[pr.ciStatus];
+        ciBadge.title = `CI: ${pr.ciStatus}`;
+        title.appendChild(ciBadge);
+    }
+
+    return title;
+}
+```
+
+- [ ] **Step 2: Syntax-check the file**
+
+```bash
+node --check src/shared/uiUtils.js
+```
+
+Expected: no output (clean pass).
+
+---
+
+## Task 7: Add `.ci-badge` Styles to Design System
+
+**Files:**
+- Modify: `src/shared/design-system.css` — append at end of file
+
+- [ ] **Step 1: Append CI badge styles**
+
+Add to the very end of `src/shared/design-system.css`:
+
+```css
+/* ========================================
+   CI/CD Status Badge
+   ======================================== */
+
+.ci-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--font-size-xs);
+  margin-left: var(--space-1);
+  line-height: 1;
+}
+
+.ci-badge--success {}
+.ci-badge--failure {}
+.ci-badge--running {}
+```
+
+---
+
+## Task 8: Final Syntax Check + Commit
+
+- [ ] **Step 1: Syntax-check all modified JS files**
+
+```bash
+node --check src/shared/githubGraphql.js src/shared/githubApi.js src/shared/uiUtils.js
+```
+
+Expected: no output (clean pass on all three files).
+
+- [ ] **Step 2: Verify `manifest.json` is unchanged**
+
+```bash
+git diff manifest.json
+```
+
+Expected: no output (no changes).
+
+- [ ] **Step 3: Commit all changes**
+
+```bash
+git add src/shared/githubGraphql.js src/shared/githubApi.js src/shared/uiUtils.js src/shared/design-system.css
+git commit -m "$(cat <<'EOF'
+feature | CI/CD status badge on PR cards (#83)
+EOF
+)"
+```
+
+---
+
+## Task 9: Manual Verification
+
+Before opening the PR, verify the feature end-to-end in Chrome.
+
+- [ ] **Step 1: Load the extension unpacked**
+
+1. Go to `chrome://extensions/` with Developer Mode enabled
+2. Click "Load unpacked" and point to the repo root
+3. If already loaded, click the refresh icon on the GitPing card
+
+- [ ] **Step 2: Verify badges appear**
+
+1. Open the GitPing popup
+2. Navigate to the "Needs Your Approval" and "Your PRs" tabs
+3. For PRs with CI checks: confirm ✅ / ❌ / 🔄 badge appears to the right of the Open/Draft badge
+4. For PRs with no CI checks or failed API call: confirm no badge appears (card unchanged)
+5. For Issues tab: confirm no CI badges appear
+
+- [ ] **Step 3: Open draft PR**
+
+```bash
+git push -u origin feature/cicd-status-badge
+gh pr create \
+  --title "feature | CI/CD status badge on PR cards" \
+  --draft \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds CI/CD status badge (✅ / ❌ / 🔄) to PR cards in the popup
+- Fetches check-runs during background polling cycle via `GET /repos/{owner}/{repo}/commits/{sha}/check-runs`
+- Scoped to 4 tabs: personal, mine, team, mentions — not issues or watched
+- Uses `Promise.allSettled` so one failed call never blocks others
+- No new permissions, no `manifest.json` changes
+
+Closes #83
+EOF
+)"
+```
+
+Return the PR URL once created.

--- a/docs/superpowers/plans/2026-05-13-graphql-checksuites.md
+++ b/docs/superpowers/plans/2026-05-13-graphql-checksuites.md
@@ -1,0 +1,386 @@
+# GraphQL checkSuites Inline CI Status — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-PR REST check-runs calls with inline `checkSuites` data in the existing GraphQL query, eliminating extra API requests per poll cycle.
+
+**Architecture:** Add `checkSuites(first: 10)` to the `commit` node in `getPrSchema()` so CI suite statuses arrive as part of the existing PR GraphQL query. Map the data in `enrichIssue()` using the existing `aggregateCiStatus` pure function with uppercase→lowercase normalisation. Remove `fetchCheckRuns`, `CI_TABS`, and the `Promise.allSettled` post-enrichment pass.
+
+**Tech Stack:** Vanilla JS ES modules, GitHub GraphQL API, Node.js built-in `node:test`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/shared/githubGraphql.js` | Add `checkSuites(first: 10)` block inside `commit` node in `getPrSchema()` (lines 67–79) |
+| `src/shared/githubApi.js` | (a) Add `ciStatus` field to card in `enrichIssue()` (line 494); (b) Remove orphaned JSDoc (lines 500–507); (c) Remove `fetchCheckRuns` function (lines 522–532); (d) Remove `CI_TABS` + `Promise.allSettled` CI pass (lines 621–632) |
+| `tests/githubApi.test.mjs` | Add normalisation `describe` block for GraphQL uppercase enums |
+
+---
+
+## Task 1: Add normalisation tests
+
+These tests verify the contract: GraphQL returns uppercase enum strings; callers must `.toLowerCase()` before passing to `aggregateCiStatus`. The tests pass immediately (the function already handles lowercase), but they pin the expected behaviour.
+
+**Files:**
+- Modify: `tests/githubApi.test.mjs`
+
+- [ ] **Step 1: Add the normalisation describe block**
+
+Open `tests/githubApi.test.mjs` and append this block after the closing `});` of the existing `aggregateCiStatus` describe block:
+
+```js
+describe('aggregateCiStatus with GraphQL checkSuites nodes (normalised)', () => {
+
+    test('handles uppercase COMPLETED/SUCCESS from GraphQL', () => {
+        const suites = [
+            { status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        ];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'success');
+    });
+
+    test('handles IN_PROGRESS suite from GraphQL', () => {
+        const suites = [{ status: 'IN_PROGRESS', conclusion: null }];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'running');
+    });
+
+    test('handles QUEUED suite from GraphQL', () => {
+        const suites = [{ status: 'QUEUED', conclusion: null }];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'running');
+    });
+
+    test('handles FAILURE conclusion from GraphQL', () => {
+        const suites = [
+            { status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { status: 'COMPLETED', conclusion: 'FAILURE' },
+        ];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+
+    test('handles TIMED_OUT conclusion from GraphQL', () => {
+        const suites = [{ status: 'COMPLETED', conclusion: 'TIMED_OUT' }];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+
+    test('handles empty checkSuites array', () => {
+        assert.equal(aggregateCiStatus([]), null);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests — expect all pass**
+
+```bash
+node --test tests/githubApi.test.mjs
+```
+
+Expected output ends with:
+```
+ℹ tests 24
+ℹ pass 24
+ℹ fail 0
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/githubApi.test.mjs
+git commit -m "feature | add GraphQL checkSuites normalisation tests (#83)"
+```
+
+---
+
+## Task 2: Add checkSuites to GraphQL schema
+
+**Files:**
+- Modify: `src/shared/githubGraphql.js` (lines 67–79)
+
+- [ ] **Step 1: Add `checkSuites` block inside the `commit` node**
+
+In `getPrSchema()`, find this block (lines 67–79):
+
+```
+                    commit {
+                        message
+                        messageHeadline
+                        messageBody
+                        messageBodyHTML
+                        committedDate
+                        author {
+                            user {
+                                login
+                                avatarUrl
+                            }
+                        }
+                    }
+```
+
+Replace it with:
+
+```
+                    commit {
+                        message
+                        messageHeadline
+                        messageBody
+                        messageBodyHTML
+                        committedDate
+                        author {
+                            user {
+                                login
+                                avatarUrl
+                            }
+                        }
+                        checkSuites(first: 10) {
+                            nodes {
+                                status
+                                conclusion
+                            }
+                        }
+                    }
+```
+
+- [ ] **Step 2: Syntax-check the file**
+
+```bash
+node --check src/shared/githubGraphql.js
+```
+
+Expected: no output (clean).
+
+- [ ] **Step 3: Run tests — all still pass**
+
+```bash
+node --test tests/githubApi.test.mjs
+```
+
+Expected:
+```
+ℹ tests 24
+ℹ pass 24
+ℹ fail 0
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/githubGraphql.js
+git commit -m "feature | add checkSuites to GraphQL PR schema (#83)"
+```
+
+---
+
+## Task 3: Map ciStatus in enrichIssue
+
+**Files:**
+- Modify: `src/shared/githubApi.js` (line 494)
+
+- [ ] **Step 1: Add `ciStatus` to the card object**
+
+In `enrichIssue()`, find the card object assignment ending at line 494–495:
+
+```js
+        head_sha: issue.headRefOid || null,
+        meta: meta
+    }
+```
+
+Replace with:
+
+```js
+        head_sha: issue.headRefOid || null,
+        ciStatus: aggregateCiStatus(
+            (issue.commits?.nodes?.[0]?.commit?.checkSuites?.nodes ?? [])
+                .map(s => ({
+                    status: s.status.toLowerCase(),
+                    conclusion: s.conclusion?.toLowerCase() ?? null,
+                }))
+        ),
+        meta: meta
+    }
+```
+
+- [ ] **Step 2: Syntax-check the file**
+
+```bash
+node --check src/shared/githubApi.js
+```
+
+Expected: no output (clean).
+
+- [ ] **Step 3: Run tests — all still pass**
+
+```bash
+node --test tests/githubApi.test.mjs
+```
+
+Expected:
+```
+ℹ tests 24
+ℹ pass 24
+ℹ fail 0
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/githubApi.js
+git commit -m "feature | map ciStatus from GraphQL checkSuites in enrichIssue (#83)"
+```
+
+---
+
+## Task 4: Remove the REST CI pass
+
+Remove three things from `src/shared/githubApi.js`:
+1. Orphaned JSDoc block (lines 500–507, refers to the old `fetchCheckRuns` signature)
+2. The `fetchCheckRuns` async function (lines 508–532 after previous edits, or thereabouts)
+3. The `CI_TABS` + `Promise.allSettled` post-enrichment block in `fetchAndFilterPullRequests`
+
+**Files:**
+- Modify: `src/shared/githubApi.js`
+
+- [ ] **Step 1: Remove the orphaned JSDoc and `fetchCheckRuns` function**
+
+Find and delete this entire block (the orphaned JSDoc + function):
+
+```js
+/**
+ * Fetch CI check-runs for a PR's head commit and return an aggregated status.
+ * @param {string} owner - Repository owner (org or user login).
+ * @param {string} repo - Repository name.
+ * @param {string} sha - The PR head commit SHA.
+ * @param {string} token - GitHub personal access token.
+ * @returns {Promise<'success'|'failure'|'running'|null>}
+ */
+async function fetchCheckRuns(owner, repo, sha, token) {
+    try {
+        const data = await fetchFromGitHub(
+            `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100`,
+            token
+        );
+        return aggregateCiStatus(data.check_runs || []);
+    } catch {
+        return null;
+    }
+}
+```
+
+- [ ] **Step 2: Remove the CI_TABS + Promise.allSettled block**
+
+In `fetchAndFilterPullRequests()`, find and delete this entire block:
+
+```js
+    // fetch CI check-runs for PR tabs only
+    const CI_TABS = ['personal', 'mine', 'team', 'mentions'];
+    await Promise.allSettled(
+        CI_TABS.flatMap(key =>
+            (results[key] || [])
+                .filter(pr => pr.card?.head_sha)
+                .map(async pr => {
+                    const [owner, repo] = pr.card.repo_name.split('/');
+                    pr.card.ciStatus = await fetchCheckRuns(owner, repo, pr.card.head_sha, token);
+                })
+        )
+    );
+```
+
+After deletion, `fetchAndFilterPullRequests` should flow directly from the enrichment loop to `setFirstUpdateTime()`:
+
+```js
+    // enrich all the results
+    Object.keys(results).forEach((key) => {
+        results[key].sort((a, b) => {
+            const aTime = new Date(a.updated_at || a.updatedAt || 0).getTime();
+            const bTime = new Date(b.updated_at || b.updatedAt || 0).getTime();
+            return bTime - aTime;
+        });
+        results[key] = results[key].map(issue => enrichIssue(issue, key));
+    });
+
+    // ensure we set the first update time -- used for display purposes
+    setFirstUpdateTime();
+
+    return results;
+```
+
+- [ ] **Step 3: Syntax-check the file**
+
+```bash
+node --check src/shared/githubApi.js
+```
+
+Expected: no output (clean).
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+node --test tests/githubApi.test.mjs
+```
+
+Expected:
+```
+ℹ tests 24
+ℹ pass 24
+ℹ fail 0
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/githubApi.js
+git commit -m "feature | remove REST check-runs pass, CI status now from GraphQL (#83)"
+```
+
+---
+
+## Task 5: Verify and push
+
+- [ ] **Step 1: Run the full test suite one final time**
+
+```bash
+node --test tests/githubApi.test.mjs
+```
+
+Expected:
+```
+ℹ tests 24
+ℹ pass 24
+ℹ fail 0
+```
+
+- [ ] **Step 2: Confirm no stray references to fetchCheckRuns or CI_TABS**
+
+```bash
+grep -rn "fetchCheckRuns\|CI_TABS" src/
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push
+```

--- a/docs/superpowers/specs/2026-05-13-cicd-status-badge-design.md
+++ b/docs/superpowers/specs/2026-05-13-cicd-status-badge-design.md
@@ -1,0 +1,178 @@
+# CI/CD Status Badge on PR Cards
+
+**Date:** 2026-05-13
+**Issue:** #83
+**Status:** Approved
+
+---
+
+## Summary
+
+Add a CI/CD status badge (✅ pass / ❌ fail / 🔄 running) to each PR card in the GitPing popup. The badge surfaces build status without requiring users to open GitHub, eliminating a context switch that happens dozens of times per day.
+
+---
+
+## Scope
+
+### In scope
+- Fetch check-runs during the background polling cycle
+- Display CI badge on cards in 4 tabs: **personal** (needs your approval), **mine** (your open PRs), **team** (needs your team's approval), **mentions** (PR conversations)
+- Aggregate all check runs to a single status per PR
+- Cache result in Chrome local storage alongside existing PR data
+
+### Out of scope
+- Issues tab — CI status is not meaningful for issues
+- Watched tab — watched items may include issues; CI status not prioritised there
+- Lazy/on-demand fetching
+- Per-check-run breakdown or tooltips listing individual checks
+
+---
+
+## Architecture
+
+```
+fetchAndFilterPullRequests()
+  │
+  ├── [existing] fetch all 6 tab categories via GraphQL
+  ├── [existing] enrichIssue() for all items → builds pr.card
+  │
+  └── [NEW] second pass over ['personal', 'mine', 'team', 'mentions']
+        │
+        ├── Promise.allSettled over all PRs in those tabs
+        │     └── fetchCheckRuns(owner, repo, head_sha, token)
+        │           └── GET /repos/{owner}/{repo}/commits/{sha}/check-runs
+        │
+        └── attach ciStatus to pr.card.ciStatus
+              'success' | 'failure' | 'running' | null
+```
+
+`enrichIssue()` remains synchronous. All failures are isolated per-card via `Promise.allSettled` — one failed check-runs call never breaks others.
+
+---
+
+## Data Layer
+
+### `githubGraphql.js` — `getPrSchema()`
+
+Add `headRefOid` to the existing PR schema (alongside the `commits` block). This is the head commit SHA returned by GitHub's GraphQL API.
+
+```
+headRefOid
+```
+
+No new permissions. No new GraphQL query — added to the existing search schema.
+
+### `githubApi.js`
+
+#### `enrichIssue()` — pass through `head_sha`
+
+```js
+card.head_sha = issue.headRefOid || null;
+```
+
+Synchronous. `headRefOid` only exists on PullRequest nodes; issues get `null`.
+
+#### New function: `fetchCheckRuns(owner, repo, sha, token)`
+
+Uses the existing `fetchFromGitHub` helper.
+
+Endpoint: `GET /repos/{owner}/{repo}/commits/{sha}/check-runs`
+
+Aggregation logic (priority order):
+1. Any `conclusion === 'failure'` or `conclusion === 'timed_out'` → `'failure'`
+2. Any `status === 'in_progress'` or `status === 'queued'` → `'running'`
+3. All `conclusion === 'success'` → `'success'`
+4. Empty array or call throws → `null`
+
+Returns: `'success' | 'failure' | 'running' | null`
+
+#### `fetchAndFilterPullRequests()` — second pass
+
+After the existing enrichment loop:
+
+```js
+const CI_TABS = ['personal', 'mine', 'team', 'mentions'];
+
+await Promise.allSettled(
+  CI_TABS.flatMap(key =>
+    (results[key] || [])
+      .filter(pr => pr.card?.head_sha)
+      .map(async pr => {
+        const [owner, repo] = pr.card.repo_name.split('/');
+        pr.card.ciStatus = await fetchCheckRuns(owner, repo, pr.card.head_sha, token);
+      })
+  )
+);
+```
+
+---
+
+## UI Layer
+
+### `uiUtils.js` — `cardTitle()`
+
+After the existing `pr-status-badge` span, append a CI badge when `pr.ciStatus` is set:
+
+```js
+if (pr.ciStatus) {
+    const ciEmoji = { success: '✅', failure: '❌', running: '🔄' };
+    const ciBadge = document.createElement('span');
+    ciBadge.className = `ci-badge ci-badge--${pr.ciStatus}`;
+    ciBadge.textContent = ciEmoji[pr.ciStatus];
+    ciBadge.title = `CI: ${pr.ciStatus}`;
+    title.appendChild(ciBadge);
+}
+```
+
+No badge rendered if `ciStatus` is `null` or `undefined`.
+
+Card visual order: `[PR icon] [title text] [Open/Draft badge] [CI badge]`
+
+### `design-system.css`
+
+```css
+.ci-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--font-size-xs);
+  margin-left: var(--space-1);
+  line-height: 1;
+}
+
+.ci-badge--success {}
+.ci-badge--failure {}
+.ci-badge--running {}
+```
+
+Modifier classes defined for future extension. Emoji carries sufficient visual meaning without additional colour styling.
+
+---
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `src/shared/githubGraphql.js` | Add `headRefOid` to `getPrSchema()` |
+| `src/shared/githubApi.js` | `card.head_sha` in `enrichIssue()`, new `fetchCheckRuns()`, second pass in `fetchAndFilterPullRequests()` |
+| `src/shared/uiUtils.js` | CI badge in `cardTitle()` |
+| `src/shared/design-system.css` | `.ci-badge` base + modifier classes |
+
+**No new files. No `manifest.json` changes. No new permissions.**
+
+---
+
+## Error Handling
+
+- `fetchCheckRuns` wraps in try/catch, returns `null` on any error
+- `Promise.allSettled` in the second pass ensures one failure never affects other cards
+- If `ciStatus` is `null`, no badge renders — card degrades gracefully
+
+---
+
+## Success Criteria
+
+- PR cards in personal, mine, team, and mentions tabs show ✅ / ❌ / 🔄 based on current check-runs
+- Cards in issues and watched tabs are unchanged
+- No badge rendered for PRs with no check-runs or failed API calls
+- `manifest.json` is unchanged
+- `node --check` passes on all modified JS files

--- a/docs/superpowers/specs/2026-05-13-graphql-checksuites-design.md
+++ b/docs/superpowers/specs/2026-05-13-graphql-checksuites-design.md
@@ -1,0 +1,129 @@
+# Design: GraphQL checkSuites Inline CI Status
+
+**Date:** 2026-05-13
+**Branch:** feature/cicd-status-badge (#83)
+**Status:** Approved
+
+## Problem
+
+The CI badge feature (PR #83) introduced a separate REST call to
+`/repos/{owner}/{repo}/commits/{sha}/check-runs` for every PR across the
+`personal`, `mine`, `team`, and `mentions` tabs after each poll cycle. At a
+1-minute polling interval this exhausted the GitHub API rate limit, causing
+non-`mine` tabs to silently return empty data. The `mine` tab survived because
+it is fetched first in the sequence.
+
+## Goal
+
+Eliminate the per-PR REST check-runs calls by folding CI status data into the
+existing GraphQL query, reducing additional API requests per poll to zero.
+
+## Chosen Approach: GraphQL `checkSuites` Inline
+
+GitHub's GraphQL API exposes `checkSuites` on `Commit` objects. Adding it to
+the existing `commits(last: 1)` block in `getPrSchema()` returns CI suite
+statuses as part of the same query already made for every PR node — no extra
+network requests.
+
+`headRefOid` is retained in the schema (useful for future work).
+
+## Design
+
+### 1. GraphQL Schema (`src/shared/githubGraphql.js`)
+
+Add `checkSuites(first: 10)` inside the `commit` node in `getPrSchema()`:
+
+```graphql
+commits(last: 1) {
+    nodes {
+        commit {
+            message
+            messageHeadline
+            messageBody
+            messageBodyHTML
+            committedDate
+            author {
+                user {
+                    login
+                    avatarUrl
+                }
+            }
+            checkSuites(first: 10) {
+                nodes {
+                    status        # QUEUED | IN_PROGRESS | COMPLETED
+                    conclusion    # SUCCESS | FAILURE | TIMED_OUT | NEUTRAL | SKIPPED | ...
+                }
+            }
+        }
+    }
+}
+```
+
+`first: 10` is sufficient for any real repo (most have 1–3 CI apps).
+
+### 2. Data Layer (`src/shared/githubApi.js`)
+
+**`enrichIssue()`** — map CI status from the new GraphQL data instead of
+leaving it for the post-enrichment pass:
+
+```js
+const checkSuiteNodes =
+    issue.commits?.nodes?.[0]?.commit?.checkSuites?.nodes ?? [];
+result.card.ciStatus = aggregateCiStatus(
+    checkSuiteNodes.map(s => ({
+        status: s.status.toLowerCase(),
+        conclusion: s.conclusion?.toLowerCase() ?? null,
+    }))
+);
+```
+
+The `.toLowerCase()` call normalises GitHub GraphQL's uppercase enum values
+(`IN_PROGRESS`, `SUCCESS`, etc.) to the lowercase format `aggregateCiStatus`
+already expects from the REST API. The pure function itself does not change.
+
+**`fetchAndFilterPullRequests()`** — remove:
+- The `CI_TABS` constant
+- The `Promise.allSettled` post-enrichment CI pass
+- The `fetchCheckRuns` function
+
+`card.head_sha` (mapped from `headRefOid`) is kept on the card object.
+
+### 3. Testing (`tests/githubApi.test.mjs`)
+
+The existing 18-test `aggregateCiStatus` suite continues to pass unchanged.
+
+Add a new `describe` block covering the uppercase-to-lowercase normalisation
+introduced by the GraphQL path:
+
+```js
+describe('aggregateCiStatus with GraphQL checkSuites nodes (normalised)', () => {
+    test('handles uppercase STATUS/CONCLUSION from GraphQL', () => {
+        const runs = [{ status: 'COMPLETED', conclusion: 'SUCCESS' }]
+            .map(s => ({ status: s.status.toLowerCase(),
+                         conclusion: s.conclusion?.toLowerCase() ?? null }));
+        assert.equal(aggregateCiStatus(runs), 'success');
+    });
+
+    test('handles in-progress GraphQL suite', () => {
+        const runs = [{ status: 'IN_PROGRESS', conclusion: null }]
+            .map(s => ({ status: s.status.toLowerCase(),
+                         conclusion: s.conclusion?.toLowerCase() ?? null }));
+        assert.equal(aggregateCiStatus(runs), 'running');
+    });
+});
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/shared/githubGraphql.js` | Add `checkSuites(first: 10)` block to `getPrSchema()` |
+| `src/shared/githubApi.js` | Add CI mapping in `enrichIssue()`; remove `fetchCheckRuns`, `CI_TABS`, `Promise.allSettled` CI pass |
+| `tests/githubApi.test.mjs` | Add normalisation tests for GraphQL uppercase enums |
+
+## Out of Scope
+
+- SHA-based caching of terminal CI statuses (can be added later if needed)
+- REST fallback for GitHub Enterprise instances with Checks API disabled
+  (can be added if a real GHE compatibility issue is reported; `headRefOid`
+  is retained to support this path)

--- a/src/shared/design-system.css
+++ b/src/shared/design-system.css
@@ -188,3 +188,19 @@ a:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
+
+/* ========================================
+   CI/CD Status Badge
+   ======================================== */
+
+.ci-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--font-size-xs);
+  margin-left: var(--space-1);
+  line-height: 1;
+}
+
+.ci-badge--success {}
+.ci-badge--failure {}
+.ci-badge--running {}

--- a/src/shared/githubApi.js
+++ b/src/shared/githubApi.js
@@ -609,6 +609,19 @@ export async function fetchAndFilterPullRequests(username, token) {
         results[key] = results[key].map(issue => enrichIssue(issue, key));
     });
 
+    // fetch CI check-runs for PR tabs only
+    const CI_TABS = ['personal', 'mine', 'team', 'mentions'];
+    await Promise.allSettled(
+        CI_TABS.flatMap(key =>
+            (results[key] || [])
+                .filter(pr => pr.card?.head_sha)
+                .map(async pr => {
+                    const [owner, repo] = pr.card.repo_name.split('/');
+                    pr.card.ciStatus = await fetchCheckRuns(owner, repo, pr.card.head_sha, token);
+                })
+        )
+    );
+
     // ensure we set the first update time -- used for display purposes
     setFirstUpdateTime();
 

--- a/src/shared/githubApi.js
+++ b/src/shared/githubApi.js
@@ -491,6 +491,13 @@ function enrichIssue(issue, gitpingType="") {
         },
         labels: labels,
         head_sha: issue.headRefOid || null,
+        ciStatus: aggregateCiStatus(
+            (issue.commits?.nodes?.[0]?.commit?.checkSuites?.nodes ?? [])
+                .map(s => ({
+                    status: s.status.toLowerCase(),
+                    conclusion: s.conclusion?.toLowerCase() ?? null,
+                }))
+        ),
         meta: meta
     }
 
@@ -505,18 +512,27 @@ function enrichIssue(issue, gitpingType="") {
  * @param {string} token - GitHub personal access token.
  * @returns {Promise<'success'|'failure'|'running'|null>}
  */
+/**
+ * Aggregate an array of check-run objects into a single CI status string.
+ * Pure function — no side effects, no network calls.
+ * @param {Array} runs - Array of GitHub check-run objects.
+ * @returns {'success'|'failure'|'running'|null}
+ */
+export function aggregateCiStatus(runs) {
+    if (!Array.isArray(runs) || runs.length === 0) return null;
+    if (runs.some(r => r.conclusion === 'failure' || r.conclusion === 'timed_out')) return 'failure';
+    if (runs.some(r => r.status === 'in_progress' || r.status === 'queued')) return 'running';
+    if (runs.every(r => r.conclusion === 'success')) return 'success';
+    return null;
+}
+
 async function fetchCheckRuns(owner, repo, sha, token) {
     try {
         const data = await fetchFromGitHub(
             `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100`,
             token
         );
-        const runs = data.check_runs || [];
-        if (runs.length === 0) return null;
-        if (runs.some(r => r.conclusion === 'failure' || r.conclusion === 'timed_out')) return 'failure';
-        if (runs.some(r => r.status === 'in_progress' || r.status === 'queued')) return 'running';
-        if (runs.every(r => r.conclusion === 'success')) return 'success';
-        return null;
+        return aggregateCiStatus(data.check_runs || []);
     } catch {
         return null;
     }

--- a/src/shared/githubApi.js
+++ b/src/shared/githubApi.js
@@ -505,14 +505,6 @@ function enrichIssue(issue, gitpingType="") {
 }
 
 /**
- * Fetch CI check-runs for a PR's head commit and return an aggregated status.
- * @param {string} owner - Repository owner (org or user login).
- * @param {string} repo - Repository name.
- * @param {string} sha - The PR head commit SHA.
- * @param {string} token - GitHub personal access token.
- * @returns {Promise<'success'|'failure'|'running'|null>}
- */
-/**
  * Aggregate an array of check-run objects into a single CI status string.
  * Pure function — no side effects, no network calls.
  * @param {Array} runs - Array of GitHub check-run objects.
@@ -524,18 +516,6 @@ export function aggregateCiStatus(runs) {
     if (runs.some(r => r.status === 'in_progress' || r.status === 'queued')) return 'running';
     if (runs.every(r => r.conclusion === 'success')) return 'success';
     return null;
-}
-
-async function fetchCheckRuns(owner, repo, sha, token) {
-    try {
-        const data = await fetchFromGitHub(
-            `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100`,
-            token
-        );
-        return aggregateCiStatus(data.check_runs || []);
-    } catch {
-        return null;
-    }
 }
 
 //
@@ -624,19 +604,6 @@ export async function fetchAndFilterPullRequests(username, token) {
         });
         results[key] = results[key].map(issue => enrichIssue(issue, key));
     });
-
-    // fetch CI check-runs for PR tabs only
-    const CI_TABS = ['personal', 'mine', 'team', 'mentions'];
-    await Promise.allSettled(
-        CI_TABS.flatMap(key =>
-            (results[key] || [])
-                .filter(pr => pr.card?.head_sha)
-                .map(async pr => {
-                    const [owner, repo] = pr.card.repo_name.split('/');
-                    pr.card.ciStatus = await fetchCheckRuns(owner, repo, pr.card.head_sha, token);
-                })
-        )
-    );
 
     // ensure we set the first update time -- used for display purposes
     setFirstUpdateTime();

--- a/src/shared/githubApi.js
+++ b/src/shared/githubApi.js
@@ -490,6 +490,7 @@ function enrichIssue(issue, gitpingType="") {
             avatar_url: owner.avatarUrl || owner.avatar_url || ''
         },
         labels: labels,
+        head_sha: issue.headRefOid || null,
         meta: meta
     }
 

--- a/src/shared/githubApi.js
+++ b/src/shared/githubApi.js
@@ -497,6 +497,31 @@ function enrichIssue(issue, gitpingType="") {
     return result;
 }
 
+/**
+ * Fetch CI check-runs for a PR's head commit and return an aggregated status.
+ * @param {string} owner - Repository owner (org or user login).
+ * @param {string} repo - Repository name.
+ * @param {string} sha - The PR head commit SHA.
+ * @param {string} token - GitHub personal access token.
+ * @returns {Promise<'success'|'failure'|'running'|null>}
+ */
+async function fetchCheckRuns(owner, repo, sha, token) {
+    try {
+        const data = await fetchFromGitHub(
+            `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100`,
+            token
+        );
+        const runs = data.check_runs || [];
+        if (runs.length === 0) return null;
+        if (runs.some(r => r.conclusion === 'failure' || r.conclusion === 'timed_out')) return 'failure';
+        if (runs.some(r => r.status === 'in_progress' || r.status === 'queued')) return 'running';
+        if (runs.every(r => r.conclusion === 'success')) return 'success';
+        return null;
+    } catch {
+        return null;
+    }
+}
+
 //
 //
 //  WATCHED FUNCTIONS

--- a/src/shared/githubGraphql.js
+++ b/src/shared/githubGraphql.js
@@ -76,6 +76,12 @@ function getPrSchema() {
                                 avatarUrl
                             }
                         }
+                        checkSuites(first: 10) {
+                            nodes {
+                                status
+                                conclusion
+                            }
+                        }
                     }
                 }
             }
@@ -274,6 +280,12 @@ query GetPullRequestDetails($owner: String!, $repo: String!, $pullNumber: Int!) 
               user {
                 login
                 avatarUrl
+              }
+            }
+            checkSuites(first: 10) {
+              nodes {
+                status
+                conclusion
               }
             }
           }

--- a/src/shared/githubGraphql.js
+++ b/src/shared/githubGraphql.js
@@ -61,6 +61,7 @@ function getPrSchema() {
                 }
             }
 
+            headRefOid
             commits(last: 1) {
                 nodes {
                     commit {

--- a/src/shared/uiUtils.js
+++ b/src/shared/uiUtils.js
@@ -248,11 +248,20 @@ function cardTitle(pr) {
     title.appendChild(statusBadge);
 
     if (pr.ciStatus) {
-        const ciEmoji = { success: '✅', failure: '❌', running: '🔄' };
+        const ciSvg = {
+            success: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="#1a7f37" fill-rule="evenodd" d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0Zm3.78 4.47a.75.75 0 0 0-1.06 0L6.75 8.44 5.28 6.97a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l4.5-4.5a.75.75 0 0 0 0-1.06Z"/></svg>',
+            failure: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="#cf222e" fill-rule="evenodd" d="M2.343 13.657A8 8 0 1 1 13.657 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042L6.94 8 4.97 9.99a.749.749 0 0 0 .326 1.275.749.749 0 0 0 .734-.215L8 9.06l1.97 1.99a.749.749 0 0 0 1.275-.326.749.749 0 0 0-.215-.734L9.06 8l1.99-1.97a.749.749 0 0 0-.326-1.275.749.749 0 0 0-.734.215L8 6.94 6.03 4.97Z"/></svg>',
+            running: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="#9a6700" fill-rule="evenodd" d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM5 8a1 1 0 1 0-2 0 1 1 0 0 0 2 0Zm4 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0Zm3 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"/></svg>',
+        };
         const ciBadge = document.createElement('span');
         ciBadge.className = `ci-badge ci-badge--${pr.ciStatus}`;
-        ciBadge.textContent = ciEmoji[pr.ciStatus];
         ciBadge.title = `CI: ${pr.ciStatus}`;
+        const ciImg = document.createElement('img');
+        ciImg.src = 'data:image/svg+xml,' + encodeURIComponent(ciSvg[pr.ciStatus]);
+        ciImg.width = 16;
+        ciImg.height = 16;
+        ciImg.alt = 'CI: ' + pr.ciStatus;
+        ciBadge.appendChild(ciImg);
         title.appendChild(ciBadge);
     }
 

--- a/src/shared/uiUtils.js
+++ b/src/shared/uiUtils.js
@@ -246,6 +246,16 @@ function cardTitle(pr) {
     }
 
     title.appendChild(statusBadge);
+
+    if (pr.ciStatus) {
+        const ciEmoji = { success: '✅', failure: '❌', running: '🔄' };
+        const ciBadge = document.createElement('span');
+        ciBadge.className = `ci-badge ci-badge--${pr.ciStatus}`;
+        ciBadge.textContent = ciEmoji[pr.ciStatus];
+        ciBadge.title = `CI: ${pr.ciStatus}`;
+        title.appendChild(ciBadge);
+    }
+
     return title;
 }
 

--- a/tests/githubApi.test.mjs
+++ b/tests/githubApi.test.mjs
@@ -1,0 +1,248 @@
+/**
+ * Tests for githubApi.js data-gathering logic.
+ *
+ * Run with:
+ *   node --test tests/githubApi.test.mjs
+ *
+ * No npm dependencies — uses Node.js built-in test runner.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// Bootstrap a minimal chrome stub BEFORE importing the module under test.
+// githubApi.js imports storageUtils.js which references chrome.storage at
+// module evaluation time, so the stub must exist first.
+// ---------------------------------------------------------------------------
+globalThis.chrome = {
+    storage: {
+        local: {
+            get: (keys, cb) => cb({}),
+            set: (_obj, cb) => cb && cb(),
+        },
+    },
+    runtime: { lastError: null },
+};
+
+// The module imports `fetch` from the global scope; stub it so imports
+// don't fail when there's no network.
+globalThis.fetch = async () => {
+    throw new Error('fetch is not stubbed for this test');
+};
+
+const { aggregateCiStatus } = await import('../src/shared/githubApi.js');
+
+// ---------------------------------------------------------------------------
+// aggregateCiStatus — pure logic, no mocking needed
+// ---------------------------------------------------------------------------
+
+describe('aggregateCiStatus', () => {
+
+    // --- null cases ---
+
+    test('returns null for empty array', () => {
+        assert.equal(aggregateCiStatus([]), null);
+    });
+
+    test('returns null for non-array input (null)', () => {
+        assert.equal(aggregateCiStatus(null), null);
+    });
+
+    test('returns null for non-array input (undefined)', () => {
+        assert.equal(aggregateCiStatus(undefined), null);
+    });
+
+    test('returns null when no runs match any known status', () => {
+        // e.g. conclusion === 'skipped' and status === 'completed'
+        const runs = [
+            { status: 'completed', conclusion: 'skipped' },
+            { status: 'completed', conclusion: 'neutral' },
+        ];
+        assert.equal(aggregateCiStatus(runs), null);
+    });
+
+    // --- success ---
+
+    test('returns success when all runs have conclusion success', () => {
+        const runs = [
+            { status: 'completed', conclusion: 'success' },
+            { status: 'completed', conclusion: 'success' },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'success');
+    });
+
+    test('returns success for a single successful run', () => {
+        assert.equal(
+            aggregateCiStatus([{ status: 'completed', conclusion: 'success' }]),
+            'success'
+        );
+    });
+
+    // --- failure ---
+
+    test('returns failure when any run has conclusion failure', () => {
+        const runs = [
+            { status: 'completed', conclusion: 'success' },
+            { status: 'completed', conclusion: 'failure' },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+
+    test('returns failure when any run has conclusion timed_out', () => {
+        const runs = [
+            { status: 'completed', conclusion: 'success' },
+            { status: 'completed', conclusion: 'timed_out' },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+
+    test('returns failure for a single timed_out run', () => {
+        assert.equal(
+            aggregateCiStatus([{ status: 'completed', conclusion: 'timed_out' }]),
+            'failure'
+        );
+    });
+
+    // --- running ---
+
+    test('returns running when any run has status in_progress', () => {
+        const runs = [
+            { status: 'completed', conclusion: 'success' },
+            { status: 'in_progress', conclusion: null },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'running');
+    });
+
+    test('returns running when any run has status queued', () => {
+        const runs = [
+            { status: 'completed', conclusion: 'success' },
+            { status: 'queued', conclusion: null },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'running');
+    });
+
+    // --- priority: failure beats running ---
+
+    test('failure takes priority over running (failure check comes first)', () => {
+        const runs = [
+            { status: 'in_progress', conclusion: null },
+            { status: 'completed', conclusion: 'failure' },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+
+    test('failure takes priority over running (timed_out + in_progress)', () => {
+        const runs = [
+            { status: 'in_progress', conclusion: null },
+            { status: 'completed', conclusion: 'timed_out' },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+
+    // --- mixed success + non-success does not return success ---
+
+    test('does not return success when some runs are skipped/neutral', () => {
+        const runs = [
+            { status: 'completed', conclusion: 'success' },
+            { status: 'completed', conclusion: 'skipped' },
+        ];
+        // 'skipped' is not 'success', so every() is false — should return null
+        assert.equal(aggregateCiStatus(runs), null);
+    });
+
+    // --- realistic GitHub check-run payloads ---
+
+    test('real-world: all checks pass', () => {
+        const runs = [
+            { name: 'lint', status: 'completed', conclusion: 'success' },
+            { name: 'test', status: 'completed', conclusion: 'success' },
+            { name: 'build', status: 'completed', conclusion: 'success' },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'success');
+    });
+
+    test('real-world: one check fails, rest pass', () => {
+        const runs = [
+            { name: 'lint', status: 'completed', conclusion: 'success' },
+            { name: 'test', status: 'completed', conclusion: 'failure' },
+            { name: 'build', status: 'completed', conclusion: 'success' },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+
+    test('real-world: checks still running', () => {
+        const runs = [
+            { name: 'lint', status: 'completed', conclusion: 'success' },
+            { name: 'test', status: 'in_progress', conclusion: null },
+            { name: 'build', status: 'queued', conclusion: null },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'running');
+    });
+
+    test('real-world: failure + still running = failure wins', () => {
+        const runs = [
+            { name: 'lint', status: 'completed', conclusion: 'failure' },
+            { name: 'test', status: 'in_progress', conclusion: null },
+        ];
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+});
+
+describe('aggregateCiStatus with GraphQL checkSuites nodes (normalised)', () => {
+
+    test('handles uppercase COMPLETED/SUCCESS from GraphQL', () => {
+        const suites = [
+            { status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        ];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'success');
+    });
+
+    test('handles IN_PROGRESS suite from GraphQL', () => {
+        const suites = [{ status: 'IN_PROGRESS', conclusion: null }];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'running');
+    });
+
+    test('handles QUEUED suite from GraphQL', () => {
+        const suites = [{ status: 'QUEUED', conclusion: null }];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'running');
+    });
+
+    test('handles FAILURE conclusion from GraphQL', () => {
+        const suites = [
+            { status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { status: 'COMPLETED', conclusion: 'FAILURE' },
+        ];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+
+    test('handles TIMED_OUT conclusion from GraphQL', () => {
+        const suites = [{ status: 'COMPLETED', conclusion: 'TIMED_OUT' }];
+        const runs = suites.map(s => ({
+            status: s.status.toLowerCase(),
+            conclusion: s.conclusion?.toLowerCase() ?? null,
+        }));
+        assert.equal(aggregateCiStatus(runs), 'failure');
+    });
+
+    test('handles empty checkSuites array', () => {
+        assert.equal(aggregateCiStatus([]), null);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds CI/CD status badge (pass / fail / running) to PR cards in the popup
- Fetches GitHub check-runs during background polling cycle
- Scoped to 4 tabs: needs your approval, your open PRs, needs your team approval, PR conversations
- Uses Promise.allSettled so one failed API call never blocks others
- No new permissions, no manifest.json changes

## Changes

- githubGraphql.js: added headRefOid to getPrSchema() to expose head commit SHA
- githubApi.js: head_sha on card object in enrichIssue(), new fetchCheckRuns() function, CI second pass in fetchAndFilterPullRequests()
- uiUtils.js: CI badge rendered in cardTitle() after existing status badge
- design-system.css: .ci-badge base styles and modifier variants

Closes #83