### PR TITLE
feature | rework review nag to use snooze + engagement gating

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -697,20 +697,15 @@ h2 {
 }
 
 .review-toast {
-    position: fixed;
-    bottom: var(--space-6);
-    right: var(--space-6);
     background: var(--color-accent-mint);
     color: var(--color-text-primary);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-lg);
-    padding: var(--space-4) var(--space-6) var(--space-4) var(--space-4);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
     display: flex;
     align-items: center;
     gap: var(--space-3);
-    z-index: var(--z-toast);
-    font-size: var(--font-size-md);
-    transition: opacity var(--transition-base);
+    font-size: var(--font-size-sm);
+    margin: var(--space-2) 0;
 }
 
 .review-toast a {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -328,21 +328,20 @@
     </div>
 
     <div id="toast" class="toast hidden"> </div>
+    <div id="review-toast" class="review-toast hidden">
+        <span>You've been using GitPing for a while — a quick review helps others find it</span>
+        <a
+            href="https://chromewebstore.google.com/detail/gitping/eekhcmlieoegmlmfeidllpdklbkbfefj/reviews"
+            target="_blank"
+            rel="noopener noreferrer"
+        >Rate on Chrome Web Store</a>
+        <button id="close-review-toast" class="close-toast-btn" aria-label="Close">&times;</button>
+    </div>
     <div id="footnote-section" class="footnote-section">
         <div id="manifest-version" class="footnote footnote-left">v1.0.0</div>
         <div id="last-update-time" class="footnote footnote-right"></div>
     </div>
     <div id="last-error" class="error hidden"></div>
-
-<div id="review-toast" class="review-toast hidden">
-    <span>Enjoying GitPing?</span>
-    <a 
-        href="https://chrome.google.com/webstore/detail/eekhcmlieoegmlmfeidllpdklbkbfefj/reviews" 
-        target="_blank" 
-        rel="noopener noreferrer"
-    >Leave a review!</a>
-    <button id="close-review-toast" class="close-toast-btn" aria-label="Close">&times;</button>
-</div>
 
     <script type="module" src="popup.js"></script>
 </body>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -328,7 +328,7 @@ async function addWatchListUrl() {
 
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', async function () {
     // Accordion logic for filter forms
     document.querySelectorAll('.filter-accordion').forEach(acc => {
         const toggle = acc.querySelector('.accordion-toggle');
@@ -643,11 +643,16 @@ document.addEventListener('DOMContentLoaded', function () {
         snoozeReviewToast();
     });
 
-    // Clicking the review link = permanent suppress
-    document.querySelector('#review-toast a')?.addEventListener('click', () => {
-        setReviewClicked();
+    // Clicking the review link = permanent suppress.
+    // Prevent default so the storage write commits before the popup can close.
+    document.querySelector('#review-toast a')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        const href = e.currentTarget.href;
+        setReviewClicked().then(() => {
+            window.open(href, '_blank');
+        });
     });
 
-    incrementPopupOpenCount();
+    await incrementPopupOpenCount();
     updateDisplaysFromStorage();
 });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -41,7 +41,7 @@ function setPopupContainerHeight() {
 }
 window.addEventListener('resize', setPopupContainerHeight);
 window.addEventListener('DOMContentLoaded', setPopupContainerHeight);
-import { getAuthToken, getUsername, resetLocalStorage, getLastUpdateTime, getLastError, setLastError, updateExtensionBadge, setLastUpdateTime, getFirstUpdateTime, setLastViewedTime, getLastViewedTime, addToWatchList, getUserReviewedExtension, setUserReviewedExtension } from '../shared/storageUtils.js';
+import { getAuthToken, getUsername, resetLocalStorage, getLastUpdateTime, getLastError, setLastError, updateExtensionBadge, setLastUpdateTime, getFirstUpdateTime, setLastViewedTime, getLastViewedTime, addToWatchList, shouldSuppressReviewToast, setReviewClicked, snoozeReviewToast, getPopupOpenCount, incrementPopupOpenCount } from '../shared/storageUtils.js';
 import { displayPullRequestsCards, resetUI, displayBadgeCount } from '../shared/uiUtils.js';
 
 // Helper: get card element by PR id
@@ -622,23 +622,32 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     async function showReviewToast() {
-        if (await getUserReviewedExtension()) {
-            return; // User has already reviewed the extension
-        }
+        if (await shouldSuppressReviewToast()) return;
 
+        // Gate 1: at least 7 days since first use
         const firstUpdateTime = await getFirstUpdateTime();
-        if (!firstUpdateTime || (Date.now() - new Date(firstUpdateTime).getTime()) < 5 * 24 * 60 * 60 * 1000) {
-            return; // Don't show the toast if it's been less than 5 days since the first update
-        }
+        if (!firstUpdateTime || (Date.now() - new Date(firstUpdateTime).getTime()) < 7 * 24 * 60 * 60 * 1000) return;
+
+        // Gate 2: at least 15 popup opens (proves real engagement)
+        const openCount = await getPopupOpenCount();
+        if (openCount < 15) return;
 
         const toast = document.getElementById('review-toast');
         if (toast) toast.classList.remove('hidden');
-        setUserReviewedExtension();
+        // Do NOT set any flag here — only on user action
     }
 
+    // Dismiss = snooze (comes back in 14 days)
     document.getElementById('close-review-toast')?.addEventListener('click', () => {
         document.getElementById('review-toast').classList.add('hidden');
+        snoozeReviewToast();
     });
 
+    // Clicking the review link = permanent suppress
+    document.querySelector('#review-toast a')?.addEventListener('click', () => {
+        setReviewClicked();
+    });
+
+    incrementPopupOpenCount();
     updateDisplaysFromStorage();
 });

--- a/src/shared/storageUtils.js
+++ b/src/shared/storageUtils.js
@@ -646,28 +646,71 @@ export async function getAppVersion() {
 //
 
 /**
- * Check if the extension has prompted for a review.
- * @returns {Promise<string>} - The last prompted time.
- * @description This function checks if the user has been prompted for a review for the extension.
+ * Check if the review toast should be suppressed.
+ * @returns {Promise<boolean>} - true if toast should NOT be shown.
  */
-export async function getUserReviewedExtension() {
+export async function shouldSuppressReviewToast() {
     return new Promise((resolve) => {
-        chrome.storage.local.get(['userReviewedExtension'], (result) => {
-            resolve(result.userReviewedExtension);
+        chrome.storage.local.get(['reviewClickedAt', 'reviewSnoozedAt', 'userReviewedExtension'], (result) => {
+            // Permanently suppress if user clicked the review link
+            if (result.reviewClickedAt) {
+                resolve(true);
+                return;
+            }
+            // Migrate legacy one-shot flag: treat as a snooze, not permanent block
+            if (result.userReviewedExtension && !result.reviewSnoozedAt) {
+                const legacyTime = new Date(result.userReviewedExtension).getTime();
+                const fourteenDays = 14 * 24 * 60 * 60 * 1000;
+                resolve(Date.now() - legacyTime < fourteenDays);
+                return;
+            }
+            // Suppress for 14 days after a dismiss/snooze
+            if (result.reviewSnoozedAt) {
+                const snoozedAt = new Date(result.reviewSnoozedAt).getTime();
+                const fourteenDays = 14 * 24 * 60 * 60 * 1000;
+                resolve(Date.now() - snoozedAt < fourteenDays);
+                return;
+            }
+            resolve(false);
         });
     });
 }
-/**
- * Set the timestamp of when a user was last prompted to review the extension.
- * @returns {Promise<void>} - A promise that resolves when the operation is complete.
- * @description This function sets the review status for the extension in local storage.
- */
-export async function setUserReviewedExtension() {
-    return new Promise((resolve) => {
-        const lastPromptedTime = new Date().toLocaleString();
 
-        chrome.storage.local.set({ userReviewedExtension: lastPromptedTime }, () => {
-            resolve();
+/**
+ * Mark that the user clicked the review link (permanent suppress).
+ */
+export async function setReviewClicked() {
+    return new Promise((resolve) => {
+        chrome.storage.local.set({ reviewClickedAt: new Date().toISOString() }, resolve);
+    });
+}
+
+/**
+ * Snooze the review toast for 14 days (dismiss without reviewing).
+ */
+export async function snoozeReviewToast() {
+    return new Promise((resolve) => {
+        chrome.storage.local.set({ reviewSnoozedAt: new Date().toISOString() }, resolve);
+    });
+}
+
+/**
+ * Get the number of times the popup has been opened (for engagement gating).
+ */
+export async function getPopupOpenCount() {
+    return new Promise((resolve) => {
+        chrome.storage.local.get(['popupOpenCount'], (result) => {
+            resolve(result.popupOpenCount || 0);
         });
+    });
+}
+
+/**
+ * Increment the popup open counter.
+ */
+export async function incrementPopupOpenCount() {
+    const count = await getPopupOpenCount();
+    return new Promise((resolve) => {
+        chrome.storage.local.set({ popupOpenCount: count + 1 }, resolve);
     });
 }

--- a/src/shared/storageUtils.js
+++ b/src/shared/storageUtils.js
@@ -657,9 +657,15 @@ export async function shouldSuppressReviewToast() {
                 resolve(true);
                 return;
             }
-            // Migrate legacy one-shot flag: treat as a snooze, not permanent block
+            // Migrate legacy one-shot flag: treat as a snooze, not permanent block.
+            // The old setter used toLocaleString(), which is not reliably parseable — treat
+            // an unparseable timestamp conservatively as "was shown recently, suppress now".
             if (result.userReviewedExtension && !result.reviewSnoozedAt) {
                 const legacyTime = new Date(result.userReviewedExtension).getTime();
+                if (isNaN(legacyTime)) {
+                    resolve(true); // Can't determine when; suppress to avoid nagging
+                    return;
+                }
                 const fourteenDays = 14 * 24 * 60 * 60 * 1000;
                 resolve(Date.now() - legacyTime < fourteenDays);
                 return;


### PR DESCRIPTION
## Summary
- **Fixes one-shot kill bug** — `setUserReviewedExtension()` was called the moment the toast appeared, permanently suppressing it after one dismissal. In production, this meant exactly one shot per user, forever.
- **Dismiss = 14-day snooze, review click = permanent suppress** — two distinct states now tracked (`reviewSnoozedAt` vs `reviewClickedAt`)
- **Engagement gating** — requires 15+ popup opens AND 7 days since first use before showing (old: just 5 calendar days, no usage signal)
- **Inline banner** — moved from `position: fixed` floating toast to inline element above the footer, feels like part of the UI rather than an interruption
- **Improved copy** — altruistic framing ("helps others find it") with concrete CTA ("Rate on Chrome Web Store"), updated to new Chrome Web Store URL
- **Legacy migration** — existing users with `userReviewedExtension` flag are treated as snoozed (not permanently blocked), giving them a fresh chance after 14 days

## New storage keys
| Key | Type | Meaning |
|-----|------|---------|
| `reviewClickedAt` | ISO timestamp | User clicked review link — permanent suppress |
| `reviewSnoozedAt` | ISO timestamp | User dismissed toast — suppress for 14 days |
| `popupOpenCount` | number | Engagement counter, incremented on every popup open |

## Test Plan
- [ ] Load extension, verify toast does NOT appear before 7 days + 15 opens
- [ ] Fast-track by setting `firstUpdateTime` to 8 days ago and `popupOpenCount` to 15 in DevTools storage
- [ ] Verify toast appears as inline banner above footer (not floating)
- [ ] Click X — verify toast hides, `reviewSnoozedAt` is set in storage, toast does NOT reappear on next open within 14 days
- [ ] Clear `reviewSnoozedAt`, reopen — verify toast reappears after snooze window
- [ ] Click "Rate on Chrome Web Store" — verify `reviewClickedAt` is set, toast never reappears
- [ ] Verify existing users with old `userReviewedExtension` key get a fresh chance after 14 days