### PR TITLE
feat: add diff size badge to PR cards

### DIFF
--- a/src/shared/design-system.css
+++ b/src/shared/design-system.css
@@ -213,3 +213,37 @@ a:focus-visible {
 .ci-badge--success {}
 .ci-badge--failure {}
 .ci-badge--running {}
+
+/* ========================================
+   Diff Stat Badge
+   ======================================== */
+
+.pr-diff-stat {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-family-mono);
+  color: var(--color-text-tertiary);
+  padding: var(--space-1) 0;
+}
+
+.pr-diff-additions {
+  color: #1a7f37;
+}
+
+.pr-diff-deletions {
+  color: #cf222e;
+}
+
+.pr-diff-files {
+  color: var(--color-text-muted);
+}
+
+.pr-diff-stat--lg {
+  font-weight: var(--font-weight-semibold);
+}
+
+.pr-diff-stat--lg .pr-diff-files {
+  color: var(--color-warning);
+}

--- a/src/shared/githubApi.js
+++ b/src/shared/githubApi.js
@@ -490,6 +490,9 @@ function enrichIssue(issue, gitpingType="") {
             avatar_url: owner.avatarUrl || owner.avatar_url || ''
         },
         labels: labels,
+        additions: issue.additions ?? null,
+        deletions: issue.deletions ?? null,
+        changedFiles: issue.changedFiles ?? null,
         head_sha: issue.headRefOid || null,
         ciStatus: aggregateCiStatus(
             (issue.commits?.nodes?.[0]?.commit?.checkSuites?.nodes ?? [])

--- a/src/shared/githubGraphql.js
+++ b/src/shared/githubGraphql.js
@@ -61,6 +61,10 @@ function getPrSchema() {
                 }
             }
 
+            additions
+            deletions
+            changedFiles
+
             headRefOid
             commits(last: 1) {
                 nodes {
@@ -266,6 +270,11 @@ query GetPullRequestDetails($owner: String!, $repo: String!, $pullNumber: Int!) 
           description
         }
       }
+
+      # --- Diff Stats ---
+      additions
+      deletions
+      changedFiles
 
       # --- Last Commit Details ---
       commits(last: 1) {

--- a/src/shared/uiUtils.js
+++ b/src/shared/uiUtils.js
@@ -150,6 +150,11 @@ export async function createPullRequestCard(pr, section_name = null, lastViewedT
             card.appendChild(quote);
         }
 
+        const diffStat = cardDiffStat(pr);
+        if (diffStat) {
+            card.appendChild(diffStat);
+        }
+
         const footnote = cardFootnote(pr, section_name, lastViewedTime);
         card.appendChild(footnote);
 
@@ -335,6 +340,46 @@ function cardTitle(pr) {
     }
 
     return title;
+}
+
+function cardDiffStat(pr) {
+    if (pr.additions == null && pr.deletions == null) return null;
+
+    const additions = pr.additions || 0;
+    const deletions = pr.deletions || 0;
+    const files = pr.changedFiles || 0;
+    const total = additions + deletions;
+
+    const container = document.createElement('div');
+    container.className = 'pr-diff-stat';
+
+    let sizeClass = 'pr-diff-stat--sm';
+    if (total >= 500) sizeClass = 'pr-diff-stat--lg';
+    else if (total >= 100) sizeClass = 'pr-diff-stat--md';
+    container.classList.add(sizeClass);
+
+    const addSpan = document.createElement('span');
+    addSpan.className = 'pr-diff-additions';
+    addSpan.textContent = `+${additions}`;
+
+    const delSpan = document.createElement('span');
+    delSpan.className = 'pr-diff-deletions';
+    delSpan.textContent = `-${deletions}`;
+
+    const filesSpan = document.createElement('span');
+    filesSpan.className = 'pr-diff-files';
+    filesSpan.textContent = `${files} file${files !== 1 ? 's' : ''}`;
+
+    const sep1 = document.createTextNode(' ');
+    const sep2 = document.createTextNode(' · ');
+
+    container.appendChild(addSpan);
+    container.appendChild(sep1);
+    container.appendChild(delSpan);
+    container.appendChild(sep2);
+    container.appendChild(filesSpan);
+
+    return container;
 }
 
 function cardFootnote(pr, section_name = null, lastViewedTime = null) {


### PR DESCRIPTION
## Summary
- Adds `additions`, `deletions`, `changedFiles` to GraphQL PR queries (search + detail)
- Passes diff stats through `enrichIssue()` into the card object
- Renders a compact `+N -N · M files` indicator on each PR card between the quote and footnote
- Size classes: small (< 100 lines), medium (100-500), large (500+ — bold + warning color on file count)

Closes #89

## Test plan
- [ ] Load extension, verify PR cards show diff stat line with green additions and red deletions
- [ ] Confirm issues do NOT show diff stat (fields are null for issues)
- [ ] Check a large PR (500+ lines) shows bold text and warning-colored file count
- [ ] Check a small PR (< 100 lines) shows normal weight
- [ ] Verify no console errors from the GraphQL query changes